### PR TITLE
Added extra URLs for the hosting pages

### DIFF
--- a/dynamicweb/urls.py
+++ b/dynamicweb/urls.py
@@ -5,12 +5,14 @@ from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 
 from django.conf import settings
-from hosting.views import railshosting
+from hosting.views import railshosting, nodejshosting, djangohosting
 from membership import urls as membership_urls
 
 urlpatterns = [
                   url(r'^hosting/', include('hosting.urls', namespace="hosting")),
                   url(r'^railshosting/', railshosting, name="rails.hosting"),
+                  url(r'^nodehosting/', nodejshosting, name="node.hosting"),
+                  url(r'^djangohosting/', djangohosting, name="django.hosting"),
                   url(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
                   url(r'^jsi18n/(?P<packages>\S+?)/$',
                       'django.views.i18n.javascript_catalog'),

--- a/hosting/templates/hosting/rails.html
+++ b/hosting/templates/hosting/rails.html
@@ -5,7 +5,7 @@
   <li><i class="fa-li fa fa-check-square-o fa-lg"></i>
   <p class="lead">Ubuntu 14.04 as the operating system, full root access!</p>
   </li>
-  <li><i class="fa-li fa fa-check-square-o fa-lg"></i><p class="lead">rbenv to let you decide which Ruby version you want to use</p></li>s
+  <li><i class="fa-li fa fa-check-square-o fa-lg"></i><p class="lead">rbenv to let you decide which Ruby version you want to use</p></li>
   <li><i class="fa-li fa fa-check-square-o fa-lg"></i><p class="lead">nginx as the frontend Server (optional with SSL Support)</p></li>
   <li><i class="fa-li fa fa-check-square-o fa-lg"></i><p class="lead">uwsgi to have your application talk to nginx and vice versa
   <li><i class="fa-li fa fa-check-square-o fa-lg"></i><p class="lead">PostgreSQL as the database</p>


### PR DESCRIPTION
Added extra URLs for the hosting pages:
/djangohosting/
/nodehosting/

The idea behind this change is to server landing pages under the domains: www.django-hosting.ch www.node-hosting.ch www.rails-hosting.ch

Also fixed a small typo in hosting/templates/hosting/rails.html

This change was tested on the staging web server by adding on the local box entries in /etc/hosts for the domains: www.django-hosting.ch www.node-hosting.ch www.rails-hosting.ch

Related tickets:
https://redmine.ungleich.ch/issues/2225
https://redmine.ungleich.ch/issues/1620
https://redmine.ungleich.ch/issues/1621