### PR TITLE
Move keys section underneath user name menu

### DIFF
--- a/hosting/templates/hosting/base_short.html
+++ b/hosting/templates/hosting/base_short.html
@@ -72,11 +72,7 @@
                                 <i class="fa fa-credit-card"></i> {% trans "My Orders"%}
                             </a>
                         </li>
-                        <li>
-                            <a href="{% url 'hosting:key_pair' %}">
-                                <i class="fa fa-key" aria-hidden="true"></i> {% trans "Keys"%}
-                            </a>
-                        </li>
+                        
                         <li>
                             <a href="{% url 'hosting:notifications' %}">
                                 <i class="fa fa-bell"></i> {% trans "Notifications "%}
@@ -87,6 +83,11 @@
                             <i class="glyphicon glyphicon-user"></i> {{request.user.name}} <span class="caret"></span></a>
                           <ul id="g-account-menu" class="dropdown-menu" role="menu">
                             <li><a href="{% url 'hosting:logout' %}"><i class="glyphicon glyphicon-lock"></i>{% trans "Logout"%} </a></li>
+							<li>
+                            <a href="{% url 'hosting:key_pair' %}">
+                                <i class="fa fa-key"></i> {% trans "Keys"%}
+                            </a>
+                        	</li>
                           </ul>
                         </li>
                     {% else %}


### PR DESCRIPTION
Test it by verifiying that the keys section is now underneath the user name menu: 
<img width="496" alt="keys" src="https://cloud.githubusercontent.com/assets/2394624/26550842/ec74e318-447f-11e7-8784-3e5520a4989d.png">
