### PR TITLE
Pcoder set debug false

### DIFF
--- a/dynamicweb/settings/base.py
+++ b/dynamicweb/settings/base.py
@@ -20,6 +20,11 @@ def env(env_name):
     return os.environ.get(env_name)
 
 
+def bool_env(val):
+    """Replaces string based environment values with Python booleans"""
+    return True if os.environ.get(val, False) == 'True' else False
+
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 PROJECT_DIR = os.path.abspath(
@@ -474,14 +479,6 @@ REGISTRATION_MESSAGE = {'subject': "Validation mail",
 STRIPE_API_PRIVATE_KEY = env('STRIPE_API_PRIVATE_KEY')
 STRIPE_API_PUBLIC_KEY = env('STRIPE_API_PUBLIC_KEY')
 
-DEBUG = True
-
-if DEBUG:
-    from .local import * # flake8: noqa
-else:
-    from .prod import * # flake8: noqa
-
-
 ANONYMOUS_USER_NAME = 'anonymous@ungleich.ch'
 GUARDIAN_GET_INIT_ANONYMOUS_USER = 'membership.models.get_anonymous_user_instance'
 
@@ -525,3 +522,10 @@ GOOGLE_ANALYTICS_PROPERTY_IDS = {
     'dynamicweb-development.ungleich.ch': 'development',
     'dynamicweb-staging.ungleich.ch': 'staging'
 }
+
+DEBUG = bool_env('DEBUG')
+
+if DEBUG:
+    from .local import * # flake8: noqa
+else:
+    from .prod import * # flake8: noqa

--- a/dynamicweb/settings/prod.py
+++ b/dynamicweb/settings/prod.py
@@ -7,6 +7,13 @@ DEBUG = False
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+    }
+}
+
 # MANAGERS = ADMINS
 
 REGISTRATION_MESSAGE['message'] = REGISTRATION_MESSAGE['message'].format(host='digitalglarus.ungleich.ch',

--- a/dynamicweb/urls.py
+++ b/dynamicweb/urls.py
@@ -43,12 +43,11 @@ urlpatterns += i18n_patterns('',
                              url(r'^blog/', include('ungleich.urls', namespace='ungleich')),
                              url(r'^', include('cms.urls'))
                              )
-
+urlpatterns += patterns('',
+                        url(r'^media/(?P<path>.*)$',
+                            'django.views.static.serve', {
+                                'document_root': settings.MEDIA_ROOT,
+                            }),
+                        )
 if settings.DEBUG:
-    urlpatterns += patterns('',
-                            url(r'^media/(?P<path>.*)$',
-                                'django.views.static.serve', {
-                                    'document_root': settings.MEDIA_ROOT,
-                                }),
-                            )
     urlpatterns += patterns('', url(r'^__debug__/', include(debug_toolbar.urls)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,3 +85,4 @@ coverage==4.3.4
 git+https://github.com/ungleich/python-oca.git#egg=python-oca
 djangorestframework
 flake8==3.3.0
+python-memcached==1.58


### PR DESCRIPTION
I proposed this PR to resolve the issue #3538 wherein we have/had DEBUG=True set in settings/base.py in production. And due to this, we were/are always loading the settings defined in local.py rather than prod.py. This PR also introduces the use of memcached cache for production and LocMemcache for development (It was always using/It still uses LocMemcache in production). In order to test this PR, you may need to set DEBUG=True in your .env file.