### PR TITLE
Removed button outline when inactive

### DIFF
--- a/datacenterlight/static/datacenterlight/css/landing-page.css
+++ b/datacenterlight/static/datacenterlight/css/landing-page.css
@@ -826,6 +826,7 @@ tech-sub-sec h2 {
     margin-top: 20px;
     font-size: 20px;
     width: 200px;
+    border: none;
 }
 .price-calc-section .card .select-configuration select{
     outline: none;


### PR DESCRIPTION
The VM calculator's button when inactive has a blue border. This PR removes that.