### PR TITLE
Added style to right align date in desktop view in Order Confirm page

### DIFF
--- a/datacenterlight/templates/datacenterlight/order_detail.html
+++ b/datacenterlight/templates/datacenterlight/order_detail.html
@@ -25,7 +25,7 @@
                     </div>
                     <hr>
                     <div class="row">
-                        <div class="col-xs-12 col-sm-6 pull-right text-left">
+                        <div class="col-xs-12 col-sm-6 pull-right order-confirm-date">
                             <address>
                                 <strong>{% trans "Date"%}:</strong><br>
                                 <span id="order-created_at">{% now "Y-m-d H:i" %}</span><br><br>

--- a/hosting/static/hosting/css/landing-page.css
+++ b/hosting/static/hosting/css/landing-page.css
@@ -541,28 +541,39 @@ a.unlink:hover {
 .card-cvc-element label {
     padding-left: 10px;
 }
+
 .card-element {
     margin-bottom: 10px;
     padding: 0;
 }
+
 .card-element label{
     width:100%;
     margin-bottom:0px;
 }
+
 .my-input {
    border-bottom: 1px solid #ccc;
  }
+
 .card-cvc-element .my-input {
     padding-left: 10px;
 }
+
 #card-errors {
     clear: both;
     padding: 0 0 10px;
     color: #eb4d5c;
 }
+
 .credit-card-goup{
     padding: 0;
 }
+
+.order-confirm-date{
+    text-align:right;
+}
+
 @media (max-width: 767px) {
     .dcl-order-table-total span {
         padding-left: 3px;
@@ -631,7 +642,11 @@ a.unlink:hover {
     #billing-form .form-control {
     box-shadow: none !important;
     font-weight: 400;
-}
+    }
+
+    .order-confirm-date{
+        text-align:left;
+    }
 }
 
 @media (min-width: 1200px) {

--- a/hosting/templates/hosting/order_detail.html
+++ b/hosting/templates/hosting/order_detail.html
@@ -24,7 +24,7 @@
     		</div>
     		<hr>
     		<div class="row">
-				<div class="col-xs-12 col-md-6 pull-right text-left">
+				<div class="col-xs-12 col-md-6 pull-right order-confirm-date">
                     <address>
                         <strong>{% trans "Date"%}:</strong><br>
                         <span id="order-created_at">{{order.created_at|date:'Y-m-d H:i'}}</span><br><br>


### PR DESCRIPTION
The date in the Order Confirm page is not properly right aligned. This PR attempts to fix that.