### PR TITLE
social icons underbars removed #3593

### DIFF
--- a/datacenterlight/templates/datacenterlight/index.html
+++ b/datacenterlight/templates/datacenterlight/index.html
@@ -9,7 +9,7 @@
 
             <div class="row">
                 <div class="col-lg-12">
-    
+
                     <div class="intro-message">
                       <h1>Data Center Light</h1>
                         <h3>{% trans "Finally, an affordable VM hosting in Switzerland!" %}</h3>
@@ -59,13 +59,13 @@
                               <li>
                                 <i class="fa-li fa fa-check-square-o fa-lg"></i>
                                 <p class="lead">{% trans "Is creative, using a modern and alternative design for a data center in order to make it more sustainable and affordable at the same time." %}</p>
-                              </li> 
+                              </li>
                               <li>
                                 <i class="fa-li fa fa-check-square-o fa-lg"></i>
                                 <p class="lead">{% trans "Cuts down the costs for you by using FOSS (Free Open Source Software) exclusively, wherefore we can save money from paying licenses." %}</p>
-                              </li> 
+                              </li>
                              </ul>
-                            
+
                         </div>
                     </div>
                 </div>
@@ -86,7 +86,7 @@
                         </div>
                         <div class="split-description">
                             <p class="lead">{% trans "We don't use special hardware. We use commodity hardware: we buy computers that you buy. Just many more and put them in a cozy home for computers called data center." %}</p>
-                            
+
                         </div>
                     </div>
                 </div>
@@ -112,7 +112,7 @@
                         </div>
                         <div class="split-description">
                             <p class="lead">{% trans "Our VMs are located in Switzerland, with reliable power supply and fast internet connection. Our VM costs less thanks to our featherlight infrastructure." %}</p>
-                            
+
                         </div>
                     </div>
                 </div>
@@ -121,7 +121,7 @@
         <!-- /.container -->
         <!-- /.option 1 -->
     </div>
-    
+
     <!-- /.content-section-b -->
     <div class="content-section-a pricing-section" id="price">
 
@@ -154,7 +154,7 @@
         <div class="intro-header-2 contact-section" id="contact">
             <div class="container">
                 <div class="row">
-                  
+
                     <div class="col-sm-6 col-md-6">
                         <div class="card">
                             <div class="subtitle">
@@ -166,15 +166,9 @@
                                 <p>{% trans "Switzerland " %}</p>
                             </div>
                             <div class="social">
-                                <a target="_blank" class="" href="https://twitter.com/datacenterlight">
-                                     <i class="fa fa-twitter fa-fw"></i>
-                                </a>
-                                <a  target="_blank"  class=""  href="https://github.com/ungleich">
-                                     <i class="fa fa-github fa-fw"></i>
-                                </a>
-                                <a  target="_blank"  class=""  href="https://www.facebook.com/ungleich.ch/">
-                                     <i class="fa fa-facebook fa-fw"></i>
-                                </a>
+                                <a target="_blank" class="" href="https://twitter.com/datacenterlight"><i class="fa fa-twitter fa-fw"></i></a>
+                                <a target="_blank"  class=""  href="https://github.com/ungleich"><i class="fa fa-github fa-fw"></i></a>
+                                <a  target="_blank"  class=""  href="https://www.facebook.com/ungleich.ch/"><i class="fa fa-facebook fa-fw"></i></a>
                             </div>
                         </div>
                     </div>
@@ -187,7 +181,7 @@
 
             </div>
         </div>
-        
+
     </div>
     <!-- /.banner -->
 {% endblock %}


### PR DESCRIPTION
underbars were caused by spaces around the icon in html (spaces around inline elements). Another alternative could have been to change a style on :active:focus, but seemed unnecessary here. 