### PR TITLE
Task/3615/decouple landing page from opennebula

### DIFF
--- a/datacenterlight/management/commands/fetchvmtemplates.py
+++ b/datacenterlight/management/commands/fetchvmtemplates.py
@@ -1,0 +1,29 @@
+from django.core.management.base import BaseCommand
+from opennebula_api.models import OpenNebulaManager
+from datacenterlight.models import VMTemplate
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Fetches the VM templates from OpenNebula and populates the dcl VMTemplate model'
+
+    def handle(self, *args, **options):
+        try:
+            manager = OpenNebulaManager()
+            templates = manager.get_templates()
+            dcl_vm_templates = []
+            for template in templates:
+                template_name = template.name.strip('public-')
+                template_id = template.id
+                dcl_vm_template = VMTemplate.create(template_name, template_id)
+                dcl_vm_templates.append(dcl_vm_template)
+
+            old_vm_templates = VMTemplate.objects.all()
+            old_vm_templates.delete()
+
+            for dcl_vm_template in dcl_vm_templates:
+                dcl_vm_template.save()
+        except Exception as e:
+            logger.error('Error connecting to OpenNebula. Error Details: {err}'.format(err=str(e)))

--- a/datacenterlight/models.py
+++ b/datacenterlight/models.py
@@ -9,12 +9,13 @@ class BetaAccessVMType(models.Model):
 
     def __str__(self):
         return "ID: %s - SSD %s - RAM %s - CPU %s - Price %s " % \
-            (self.id, str(self.ssd), self.ram, self.cpu, self.price)
+               (self.id, str(self.ssd), self.ram, self.cpu, self.price)
 
 
 class BetaAccess(models.Model):
     email = models.CharField(max_length=250)
     name = models.CharField(max_length=250)
+
     # vm = models.ForeignKey(BetaAccessVM)
 
     def __str__(self):
@@ -48,3 +49,13 @@ class BetaAccessVM(models.Model):
                                                   amount=vm[VM_AMOUNT], type=vm_type))
 
         return created_vms
+
+
+class VMTemplate(models.Model):
+    name = models.CharField(max_length=50)
+    opennebula_vm_id = models.IntegerField()
+
+    @classmethod
+    def create(cls, name, opennebula_vm_id):
+        vm_template = cls(name=name, opennebula_vm_id=opennebula_vm_id)
+        return vm_template

--- a/datacenterlight/models.py
+++ b/datacenterlight/models.py
@@ -53,9 +53,9 @@ class BetaAccessVM(models.Model):
 
 class VMTemplate(models.Model):
     name = models.CharField(max_length=50)
-    opennebula_vm_id = models.IntegerField()
+    opennebula_vm_template_id = models.IntegerField()
 
     @classmethod
-    def create(cls, name, opennebula_vm_id):
-        vm_template = cls(name=name, opennebula_vm_id=opennebula_vm_id)
+    def create(cls, name, opennebula_vm_template_id):
+        vm_template = cls(name=name, opennebula_vm_template_id=opennebula_vm_template_id)
         return vm_template

--- a/datacenterlight/templates/datacenterlight/calculator_form.html
+++ b/datacenterlight/templates/datacenterlight/calculator_form.html
@@ -2,7 +2,7 @@
 <form id="order_form" method="POST" action="" data-toggle="validator" role="form">
     {% csrf_token %}
     <div class="title">
-       <h3>{% trans "VM hosting" %} </h3>
+        <h3>{% trans "VM hosting" %} </h3>
     </div>
     <div class="price">
         <span id="total">15</span>
@@ -17,28 +17,31 @@
         </div>
         <div class="form-group">
             <div class="description input">
-            <i class="fa fa-minus-circle left" data-minus="cpu" aria-hidden="true"></i>
-            <input class="input-price select-number" type="number"  min="1" max="48" id="coreValue" name="cpu" data-error="{% trans 'Please enter a value in range 1 - 48.' %}" required>
-            <span> Core</span>
-            <i class="fa fa-plus-circle right" data-plus="cpu"  aria-hidden="true"></i>
+                <i class="fa fa-minus-circle left" data-minus="cpu" aria-hidden="true"></i>
+                <input class="input-price select-number" type="number" min="1" max="48" id="coreValue" name="cpu"
+                       data-error="{% trans 'Please enter a value in range 1 - 48.' %}" required>
+                <span> Core</span>
+                <i class="fa fa-plus-circle right" data-plus="cpu" aria-hidden="true"></i>
             </div>
             <div class="help-block with-errors"></div>
         </div>
         <div class="form-group">
             <div class="description input">
-            <i class="fa fa-minus-circle left" data-minus="ram" aria-hidden="true"></i>
-            <input id="ramValue" class="input-price select-number" type="number"  min="2" max="200"  name="ram" data-error="{% trans 'Please enter a value in range 2 - 200.' %}" required>
-            <span> GB RAM</span>
-            <i class="fa fa-plus-circle right" data-plus="ram"  aria-hidden="true"></i>
+                <i class="fa fa-minus-circle left" data-minus="ram" aria-hidden="true"></i>
+                <input id="ramValue" class="input-price select-number" type="number" min="2" max="200" name="ram"
+                       data-error="{% trans 'Please enter a value in range 2 - 200.' %}" required>
+                <span> GB RAM</span>
+                <i class="fa fa-plus-circle right" data-plus="ram" aria-hidden="true"></i>
             </div>
             <div class="help-block with-errors"></div>
         </div>
         <div class="form-group">
             <div class="description input">
-            <i class="fa fa-minus-circle left" data-minus="storage" aria-hidden="true"></i>
-            <input id="storageValue" class="input-price select-number" type="number"  min="10" max="2000" step="10" name="storage" data-error="{% trans 'Please enter a value in range 10 - 2000.' %}" required>
-            <span>{% trans "GB Storage (SSD)" %}</span>
-            <i class="fa fa-plus-circle right" data-plus="storage"  aria-hidden="true"></i>
+                <i class="fa fa-minus-circle left" data-minus="storage" aria-hidden="true"></i>
+                <input id="storageValue" class="input-price select-number" type="number" min="10" max="2000" step="10"
+                       name="storage" data-error="{% trans 'Please enter a value in range 10 - 2000.' %}" required>
+                <span>{% trans "GB Storage (SSD)" %}</span>
+                <i class="fa fa-plus-circle right" data-plus="storage" aria-hidden="true"></i>
             </div>
             <div class="help-block with-errors"></div>
         </div>
@@ -46,7 +49,7 @@
             <label for="config">OS</label>
             <select name="config" id="">
                 {% for template in templates %}
-                    <option value="{{template.id}}">{{template.name}} </option>
+                <option value="{{template.opennebula_vm_template_id}}">{{template.name}}</option>
                 {% endfor %}
             </select>
         </div>
@@ -56,31 +59,38 @@
         </div>-->
         <div class="form-group">
             <div class="description input justify-center">
-            <label for="name" class="control-label">{% trans "Name"%}</label>
-            <input type="text" name="name" class="form-control" placeholder="{% trans 'Your Name'%}" data-minlength="3" data-error="{% trans 'Please enter your name.' %}" required>
+                <label for="name" class="control-label">{% trans "Name"%}</label>
+                <input type="text" name="name" class="form-control" placeholder="{% trans 'Your Name'%}"
+                       data-minlength="3" data-error="{% trans 'Please enter your name.' %}" required>
             </div>
             <div class="help-block with-errors">
                 {% for message in messages %}
-                    {% if 'name' in message.tags %}
-                    <ul class="list-unstyled"><li>
+                {% if 'name' in message.tags %}
+                <ul class="list-unstyled">
+                    <li>
                         {{ message|safe }}
-                    </li></ul>
-                    {% endif %}
+                    </li>
+                </ul>
+                {% endif %}
                 {% endfor %}
             </div>
         </div>
         <div class="form-group">
             <div class="description input justify-center">
-            <label for="email" class="control-label">{% trans "Email"%}</label>
-            <input name="email" type="email" pattern="^[^@\s]+@([^@\s]+\.)+[^@\s]+$" class="form-control" placeholder="{% trans 'Your Email' %}" data-error="{% trans 'Please enter a valid email address.' %}" required>
+                <label for="email" class="control-label">{% trans "Email"%}</label>
+                <input name="email" type="email" pattern="^[^@\s]+@([^@\s]+\.)+[^@\s]+$" class="form-control"
+                       placeholder="{% trans 'Your Email' %}"
+                       data-error="{% trans 'Please enter a valid email address.' %}" required>
             </div>
             <div class="help-block with-errors">
                 {% for message in messages %}
-                    {% if 'email' in message.tags %}
-                     <ul class="list-unstyled"><li>
+                {% if 'email' in message.tags %}
+                <ul class="list-unstyled">
+                    <li>
                         {{ message|safe }}
-                    </li></ul>
-                    {% endif %}
+                    </li>
+                </ul>
+                {% endif %}
                 {% endfor %}
             </div>
         </div>

--- a/datacenterlight/views.py
+++ b/datacenterlight/views.py
@@ -304,25 +304,6 @@ class WhyDataCenterLightView(IndexView):
     template_name = "datacenterlight/whydatacenterlight.html"
     model = BetaAccess
 
-    @cache_control(no_cache=True, must_revalidate=True, no_store=True)
-    def get(self, request, *args, **kwargs):
-        try:
-            manager = OpenNebulaManager()
-            templates = manager.get_templates()
-            context = {
-                'templates': VirtualMachineTemplateSerializer(templates, many=True).data,
-            }
-        except:
-            messages.error(
-                request,
-                'We have a temporary problem to connect to our backend. \
-                Please try again in a few minutes'
-            )
-            context = {
-                'error': 'connection'
-            }
-        return render(request, self.template_name, context)
-
 
 class PaymentOrderView(FormView):
     template_name = 'hosting/payment.html'

--- a/datacenterlight/views.py
+++ b/datacenterlight/views.py
@@ -212,9 +212,7 @@ class IndexView(CreateView):
         storage = request.POST.get('storage')
         price = request.POST.get('total')
         template_id = int(request.POST.get('config'))
-        manager = OpenNebulaManager()
-        template = manager.get_template(template_id)
-        template_data = VirtualMachineTemplateSerializer(template).data
+        template_data = VMTemplate.objects.all()
 
         name = request.POST.get('name')
         email = request.POST.get('email')

--- a/datacenterlight/views.py
+++ b/datacenterlight/views.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from membership.models import CustomUser, StripeCustomer
 
 from opennebula_api.models import OpenNebulaManager
-from opennebula_api.serializers import VirtualMachineTemplateSerializer, VirtualMachineSerializer
+from opennebula_api.serializers import VirtualMachineTemplateSerializer, VirtualMachineSerializer, VMTemplateSerializer
 
 
 class LandingProgramView(TemplateView):
@@ -212,7 +212,8 @@ class IndexView(CreateView):
         storage = request.POST.get('storage')
         price = request.POST.get('total')
         template_id = int(request.POST.get('config'))
-        template_data = VMTemplate.objects.all()
+        template = VMTemplate.objects.filter(opennebula_vm_template_id=template_id).first()
+        template_data = VMTemplateSerializer(template).data
 
         name = request.POST.get('name')
         email = request.POST.get('email')

--- a/opennebula_api/models.py
+++ b/opennebula_api/models.py
@@ -59,7 +59,7 @@ class OpenNebulaManager():
                 domain=settings.OPENNEBULA_DOMAIN,
                 port=settings.OPENNEBULA_PORT,
                 endpoint=settings.OPENNEBULA_ENDPOINT
-        ))
+            ))
 
     def _get_opennebula_client(self, username, password):
         return oca.Client("{0}:{1}".format(
@@ -71,7 +71,7 @@ class OpenNebulaManager():
                 domain=settings.OPENNEBULA_DOMAIN,
                 port=settings.OPENNEBULA_PORT,
                 endpoint=settings.OPENNEBULA_ENDPOINT
-        ))
+            ))
 
     def _get_user(self, user):
         """Get the corresponding opennebula user for a CustomUser object
@@ -325,7 +325,7 @@ class OpenNebulaManager():
             public_templates = [
                 template
                 for template in self._get_template_pool()
-                if 'public-' in template.name
+                if template.name.startswith('public-')
             ]
             return public_templates
         except ConnectionRefusedError:
@@ -396,7 +396,7 @@ class OpenNebulaManager():
 
     def delete_template(self, template_id):
         self.oneadmin_client.call(oca.VmTemplate.METHODS[
-                                  'delete'], template_id, False)
+                                      'delete'], template_id, False)
 
     def change_user_password(self, new_password):
         self.oneadmin_client.call(

--- a/opennebula_api/serializers.py
+++ b/opennebula_api/serializers.py
@@ -129,6 +129,12 @@ class VirtualMachineSerializer(serializers.Serializer):
         return obj.name.strip('public-')
 
 
+class VMTemplateSerializer(serializers.Serializer):
+    """Serializer to map the VMTemplate instance into JSON format."""
+    id = serializers.IntegerField(read_only=True, source='opennebula_vm_template_id')
+    name = serializers.CharField(read_only=True)
+
+
 def hexstr2int(string):
     return int(string.replace(':', ''), 16)
 


### PR DESCRIPTION
This PR is the first little step in decoupling of OpenNebula from dcl. In this PR, I try to remove the dependency on OpenNebula to fetch the VM templates shown in the landing page calculator. The solution involved creating a management command.

I call the management command `fetchvmtemplates`. We only need (1) the template name and (2) OpenNebula vm template id, and that is what the VMTemplate model that I proposed in this PR, composed of. 

When this is run, it (1) fetches the VM templates from OpenNebula, (2) extracts the name and opennebula vm template id in them to create the VMTemplate objects, (3) deletes the old vm templates if any, and (4) then saves the new VMTemplate objects.

Some Notes on this PR:
1. It needs a db migration in the datacenterlight app.
2. We need to run `python manage.py fetchvmtemplates` at least once, so that the DB model is filled with the templates.
3. This PR decouples the Data Center Light's landing page only. Further, in the flow, after the user has made the payment, we create a VM using xml-rpc call. So, we still have some dependency on OpenNebula in the VM purchase flow.
4. This PR also fixes the bug where the code checks the presence of the keyword "public-" in the template name, rather than strictly checking if the template name begins with "public-".
