### PR TITLE
Bug/3623/hosting my orders header fix

### DIFF
--- a/hosting/templates/hosting/order_detail.html
+++ b/hosting/templates/hosting/order_detail.html
@@ -20,7 +20,7 @@
     <div class="row">  
         <div class="col-xs-12 col-md-8 col-md-offset-2">
     		<div class="invoice-title">
-    			<h2>{% trans "Confirm Order"%}</h2><h3 class="pull-right">{% trans "Order #"%} {{order.id}}</h3>
+    			<h2>{{page_header_text}}</h2><h3 class="pull-right">{% trans "Order #"%} {{order.id}}</h3>
     		</div>
     		<hr>
     		<div class="row">

--- a/hosting/views.py
+++ b/hosting/views.py
@@ -600,7 +600,7 @@ class PaymentVMView(LoginRequiredMixin, FormView):
             email = BaseEmail(**email_data)
             email.send()
 
-            return HttpResponseRedirect(reverse('hosting:orders', kwargs={'pk': order.id}))
+            return HttpResponseRedirect("{url}?{query_params}".format(url=reverse('hosting:orders', kwargs={'pk': order.id}), query_params='page=payment'))
         else:
             return self.form_invalid(form)
 
@@ -619,6 +619,10 @@ class OrdersHostingDetailView(PermissionRequiredMixin, LoginRequiredMixin, Detai
         owner = self.request.user
         manager = OpenNebulaManager(email=owner.email,
                                     password=owner.password)
+        if self.request.GET.get('page', '') == 'payment':
+            context['page_header_text'] = _('Confirm Order')
+        else:
+            context['page_header_text'] = _('Invoice')
         try:
             vm = manager.get_vm(obj.vm_id)
             context['vm'] = VirtualMachineSerializer(vm).data

--- a/hosting/views.py
+++ b/hosting/views.py
@@ -32,7 +32,6 @@ from opennebula_api.serializers import VirtualMachineSerializer, \
     VirtualMachineTemplateSerializer
 from django.utils.translation import ugettext_lazy as _
 
-
 CONNECTION_ERROR = "Your VMs cannot be displayed at the moment due to a backend \
                     connection error. please try again in a few minutes."
 
@@ -563,7 +562,7 @@ class PaymentVMView(LoginRequiredMixin, FormView):
 
             # Create a Hosting Bill
             HostingBill.create(
-                 customer=customer, billing_address=billing_address)
+                customer=customer, billing_address=billing_address)
 
             # Create Billing Address for User if he does not have one
             if not customer.user.billing_addresses.count():
@@ -600,7 +599,9 @@ class PaymentVMView(LoginRequiredMixin, FormView):
             email = BaseEmail(**email_data)
             email.send()
 
-            return HttpResponseRedirect("{url}?{query_params}".format(url=reverse('hosting:orders', kwargs={'pk': order.id}), query_params='page=payment'))
+            return HttpResponseRedirect(
+                "{url}?{query_params}".format(url=reverse('hosting:orders', kwargs={'pk': order.id}),
+                                              query_params='page=payment'))
         else:
             return self.form_invalid(form)
 


### PR DESCRIPTION
The ways to test this PR

Test header is "Confirm Order" when buying a VM:

1. Login to the hosting app. (/hosting)
2. Create a VM by following the "New VM" link in the /my-virtual-machines
3. When you are in the payment page, verify that the header of the page is "Confirm Order" and not "Invoice"

Test header is "Invoice" when looking at a past order:

1. When logged into the hosting app, goto the "My Orders" page.
2. Click on any one of the VMs for details.
3. Check the header of the page. It should be "Invoice".