### PR TITLE
bug/3627/Add missing outline border around the text

### DIFF
--- a/hosting/static/hosting/css/landing-page.css
+++ b/hosting/static/hosting/css/landing-page.css
@@ -538,6 +538,10 @@ a.unlink:hover {
     padding: 5px;
 }
 
+.card-warning-addtional-margin {
+    margin-top: 15px;
+}
+
 .stripe-payment-btn {
     outline: none;
     width: auto;

--- a/hosting/templates/hosting/payment.html
+++ b/hosting/templates/hosting/payment.html
@@ -86,7 +86,7 @@
                             </form>
                             <div class="row">
                                 <div class="col-xs-12">
-                                    <p>
+                                    <p class="card-warning-content card-warning-addtional-margin">
                                         {% blocktrans %}
                                         You are not making any payment yet. After submitting your card
                                         information, you will be taken to the Confirm Order Page.


### PR DESCRIPTION
To test this PR:

1. Login to the hosting app
2. Order a VM if not already done. If you already ordered a VM goto step 3
3. Create a VM via "Create VM" Button in /my-virtual-machines page
4. When in payment page, you should find an outline border around the "You are not making any ..." text