### PR TITLE
Task/3699/Added oneadmin ssh key by default to the created VM via DCL flow

### DIFF
--- a/datacenterlight/views.py
+++ b/datacenterlight/views.py
@@ -482,6 +482,7 @@ class OrderConfirmationView(DetailView):
         vm_id = manager.create_vm(
             template_id=vm_template_id,
             specs=specs,
+            ssh_key=settings.ONEADMIN_USER_SSH_PUBLIC_KEY,
             vm_name="{email}-{template_name}-{date}".format(
                 email=user.get('email'),
                 template_name=template.get('name'),

--- a/dynamicweb/settings/base.py
+++ b/dynamicweb/settings/base.py
@@ -504,6 +504,9 @@ OPENNEBULA_PORT = env('OPENNEBULA_PORT')
 # default value is /RPC2
 OPENNEBULA_ENDPOINT = env('OPENNEBULA_ENDPOINT')
 
+# The public ssh key of the oneadmin user
+ONEADMIN_USER_SSH_PUBLIC_KEY = env('ONEADMIN_USER_SSH_PUBLIC_KEY')
+
 # dcl email configurations
 DCL_TEXT = env('DCL_TEXT')
 DCL_SUPPORT_FROM_ADDRESS = env('DCL_SUPPORT_FROM_ADDRESS')


### PR DESCRIPTION
This PR tries to add the ssh key of the oneadmin user to the VM created after a purchase.

To test this:
1. Add a parameter `ONEADMIN_USER_SSH_PUBLIC_KEY` to the .env. Set it to the desired value.
2. Create a VM using DCL landing page calculator
3. Try logging in to the VM via ssh