### PR TITLE
Bugfix/add host to celery mails

### DIFF
--- a/datacenterlight/tasks.py
+++ b/datacenterlight/tasks.py
@@ -1,5 +1,6 @@
 from dynamicweb.celery import app
 from celery.utils.log import get_task_logger
+from celery import current_task
 from django.conf import settings
 from opennebula_api.models import OpenNebulaManager
 from opennebula_api.serializers import VirtualMachineSerializer
@@ -45,6 +46,7 @@ def create_vm_task(self, vm_template_id, user, specs, template,
                    stripe_customer_id, billing_address_data,
                    billing_address_id,
                    charge, cc_details):
+    logger.debug("Running create_vm_task on {}".format(current_task.request.hostname))
     vm_id = None
     try:
         final_price = specs.get('price')
@@ -134,8 +136,8 @@ def create_vm_task(self, vm_template_id, user, specs, template,
             email_data = {
                 'subject': '{} CELERY TASK ERROR: {}'.format(settings.DCL_TEXT,
                                                              msg_text),
-                'from_email': settings.DCL_SUPPORT_FROM_ADDRESS,
-                'to': ['info@ungleich.ch'],
+                'from_email': current_task.request.hostname,
+                'to': settings.DCL_ERROR_EMAILS_TO_LIST,
                 'body': ',\n'.join(str(i) for i in self.request.args)
             }
             email = EmailMessage(**email_data)

--- a/dynamicweb/settings/base.py
+++ b/dynamicweb/settings/base.py
@@ -173,7 +173,8 @@ TEMPLATES = [
                  os.path.join(PROJECT_DIR, 'nosystemd/templates/'),
                  os.path.join(PROJECT_DIR,
                               'ungleich/templates/djangocms_blog/'),
-                 os.path.join(PROJECT_DIR, 'ungleich/templates/cms/ungleichch'),
+                 os.path.join(PROJECT_DIR,
+                              'ungleich/templates/cms/ungleichch'),
                  os.path.join(PROJECT_DIR, 'ungleich/templates/ungleich'),
                  os.path.join(PROJECT_DIR,
                               'ungleich_page/templates/ungleich_page'),
@@ -559,8 +560,20 @@ CELERY_RESULT_BACKEND = env('CELERY_RESULT_BACKEND')
 CELERY_ACCEPT_CONTENT = ['application/json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
-#CELERY_TIMEZONE = 'Europe/Zurich'
+# CELERY_TIMEZONE = 'Europe/Zurich'
 CELERY_MAX_RETRIES = int_env('CELERY_MAX_RETRIES', 5)
+
+DCL_ERROR_EMAILS_TO = env('DCL_ERROR_EMAILS_TO_ADDRESS')
+
+DCL_ERROR_EMAILS_TO_LIST = []
+if DCL_ERROR_EMAILS_TO is not None:
+    DCL_ERROR_EMAILS_TO_ADDRESS_LIST = [x.strip() for x in
+                                        DCL_ERROR_EMAILS_TO.split(
+                                            ',')] \
+        if "," in DCL_ERROR_EMAILS_TO else [DCL_ERROR_EMAILS_TO.strip()]
+
+if 'info@ungleich.ch' not in DCL_ERROR_EMAILS_TO_LIST:
+    DCL_ERROR_EMAILS_TO_LIST.append('info@ungleich.ch')
 
 ENABLE_DEBUG_LOGGING = bool_env('ENABLE_DEBUG_LOGGING')
 

--- a/dynamicweb/settings/base.py
+++ b/dynamicweb/settings/base.py
@@ -563,12 +563,12 @@ CELERY_RESULT_SERIALIZER = 'json'
 # CELERY_TIMEZONE = 'Europe/Zurich'
 CELERY_MAX_RETRIES = int_env('CELERY_MAX_RETRIES', 5)
 
-DCL_ERROR_EMAILS_TO = env('DCL_ERROR_EMAILS_TO_ADDRESS')
+DCL_ERROR_EMAILS_TO = env('DCL_ERROR_EMAILS_TO')
 
 DCL_ERROR_EMAILS_TO_LIST = []
 if DCL_ERROR_EMAILS_TO is not None:
-    DCL_ERROR_EMAILS_TO_ADDRESS_LIST = [x.strip() for x in
-                                        DCL_ERROR_EMAILS_TO.split(
+    DCL_ERROR_EMAILS_TO_LIST = [x.strip() for x in
+                                DCL_ERROR_EMAILS_TO.split(
                                             ',')] \
         if "," in DCL_ERROR_EMAILS_TO else [DCL_ERROR_EMAILS_TO.strip()]
 


### PR DESCRIPTION
This PR intends to fix the from email addresses in the error mails that are sent from celery. The from address should now contain the hostname of the machine.

Additionally the PR also introduces an env varaible `DCL_ERROR_EMAILS_TO` which could be set to a csv of emails who receive the DCL error emails. By default this is set to info@ungleich.ch