### PR TITLE
Fix broken subdomain - digitalglarus.ungliech.ch

### DIFF
--- a/dynamicweb/settings/prod.py
+++ b/dynamicweb/settings/prod.py
@@ -16,7 +16,7 @@ CACHES = {
 
 # MANAGERS = ADMINS
 
-REGISTRATION_MESSAGE['message'] = REGISTRATION_MESSAGE['message'].format(host='digitalglarus.ungleich.ch',
+REGISTRATION_MESSAGE['message'] = REGISTRATION_MESSAGE['message'].format(host='digitalglarus.ch',
                                                                          slug='{slug}')  # flake8: noqa
 
 ALLOWED_HOSTS = [

--- a/ungleich_page/templates/ungleich_page/includes/_about.html
+++ b/ungleich_page/templates/ungleich_page/includes/_about.html
@@ -64,7 +64,7 @@
               <div class="timeline-body">
                 <p>{% trans "ungleich introduces HA-Hosting" %} </p>
                 <p>{% trans "and introduces affordable 24X7 support." %}</p>
-                <p>{% trans "ungleich launches" %}<a href="https://digitalglarus.ungleich.ch/digitalglarus/">
+                <p>{% trans "ungleich launches" %}<a href="https://digitalglarus.ch">
                     {% trans "Digital Glarus project" %}</a></p>
               </div>
             </div>


### PR DESCRIPTION
Replaced all occurrences of digitalglarus.ungliech.ch with digitalglarus.ch