### PR TITLE
Task/3736/refactor compute vm price

### DIFF
--- a/datacenterlight/tests.py
+++ b/datacenterlight/tests.py
@@ -12,6 +12,7 @@ from datacenterlight.models import VMTemplate
 from datacenterlight.tasks import create_vm_task
 from membership.models import StripeCustomer
 from opennebula_api.serializers import VMTemplateSerializer
+from utils.hosting_utils import get_vm_price
 from utils.models import BillingAddress
 from utils.stripe_utils import StripeUtils
 
@@ -94,12 +95,11 @@ class CeleryTaskTestCase(TestCase):
         cpu = specs.get('cpu')
         memory = specs.get('memory')
         disk_size = specs.get('disk_size')
-        amount_to_be_charged = (cpu * 5) + (memory * 2) + (disk_size * 0.6)
-        plan_name = "{cpu} Cores, {memory} GB RAM, {disk_size} GB SSD".format(
-            cpu=cpu,
-            memory=memory,
-            disk_size=disk_size)
-
+        amount_to_be_charged = get_vm_price(cpu=cpu, memory=memory,
+                                            disk_size=disk_size)
+        plan_name = StripeUtils.get_stripe_plan_name(cpu=cpu,
+                                                     memory=memory,
+                                                     disk_size=disk_size)
         stripe_plan_id = StripeUtils.get_stripe_plan_id(cpu=cpu,
                                                         ram=memory,
                                                         ssd=disk_size,

--- a/datacenterlight/views.py
+++ b/datacenterlight/views.py
@@ -17,6 +17,7 @@ from opennebula_api.models import OpenNebulaManager
 from opennebula_api.serializers import VirtualMachineTemplateSerializer, \
     VMTemplateSerializer
 from utils.forms import BillingAddressForm
+from utils.hosting_utils import get_vm_price
 from utils.mailer import BaseEmail
 from utils.stripe_utils import StripeUtils
 from utils.tasks import send_plain_email_task
@@ -532,12 +533,11 @@ class OrderConfirmationView(DetailView):
         cpu = specs.get('cpu')
         memory = specs.get('memory')
         disk_size = specs.get('disk_size')
-        amount_to_be_charged = (cpu * 5) + (memory * 2) + (disk_size * 0.6)
-        plan_name = "{cpu} Cores, {memory} GB RAM, {disk_size} GB SSD".format(
-            cpu=cpu,
-            memory=memory,
-            disk_size=disk_size)
-
+        amount_to_be_charged = get_vm_price(cpu=cpu, memory=memory,
+                                            disk_size=disk_size)
+        plan_name = StripeUtils.get_stripe_plan_name(cpu=cpu,
+                                                     memory=memory,
+                                                     disk_size=disk_size)
         stripe_plan_id = StripeUtils.get_stripe_plan_id(cpu=cpu,
                                                         ram=memory,
                                                         ssd=disk_size,

--- a/hosting/views.py
+++ b/hosting/views.py
@@ -35,6 +35,7 @@ from utils.mailer import BaseEmail
 from utils.stripe_utils import StripeUtils
 from utils.views import PasswordResetViewMixin, PasswordResetConfirmViewMixin, \
     LoginViewMixin
+from utils.hosting_utils import get_vm_price
 from .forms import HostingUserSignupForm, HostingUserLoginForm, \
     UserHostingKeyForm, generate_ssh_key_name
 from .mixins import ProcessVMSelectionMixin
@@ -724,12 +725,11 @@ class OrdersHostingDetailView(LoginRequiredMixin,
         cpu = specs.get('cpu')
         memory = specs.get('memory')
         disk_size = specs.get('disk_size')
-        amount_to_be_charged = (cpu * 5) + (memory * 2) + (disk_size * 0.6)
-        plan_name = "{cpu} Cores, {memory} GB RAM, {disk_size} GB SSD".format(
-            cpu=cpu,
-            memory=memory,
-            disk_size=disk_size)
-
+        amount_to_be_charged = get_vm_price(cpu=cpu, memory=memory,
+                                            disk_size=disk_size)
+        plan_name = StripeUtils.get_stripe_plan_name(cpu=cpu,
+                                                     memory=memory,
+                                                     disk_size=disk_size)
         stripe_plan_id = StripeUtils.get_stripe_plan_id(cpu=cpu,
                                                         ram=memory,
                                                         ssd=disk_size,
@@ -775,8 +775,8 @@ class OrdersHostingDetailView(LoginRequiredMixin,
             'redirect': reverse('hosting:virtual_machines'),
             'msg_title': str(_('Thank you for the order.')),
             'msg_body': str(_('Your VM will be up and running in a few moments.'
-                          ' We will send you a confirmation email as soon as'
-                          ' it is ready.'))
+                              ' We will send you a confirmation email as soon as'
+                              ' it is ready.'))
         }
 
         return HttpResponse(json.dumps(response),

--- a/utils/hosting_utils.py
+++ b/utils/hosting_utils.py
@@ -9,3 +9,16 @@ def get_all_public_keys(customer):
     """
     return UserHostingKey.objects.filter(user_id=customer.id).values_list(
         "public_key", flat=True)
+
+
+def get_vm_price(cpu, memory, disk_size):
+    """
+    A helper function that computes price of a VM from given cpu, ram and
+    ssd parameters
+
+    :param cpu: Number of cores of the VM
+    :param memory: RAM of the VM
+    :param disk_size: Disk space of the VM
+    :return: The price of the VM
+    """
+    return (cpu * 5) + (memory * 2) + (disk_size * 0.6)

--- a/utils/stripe_utils.py
+++ b/utils/stripe_utils.py
@@ -238,7 +238,7 @@ class StripeUtils(object):
     @staticmethod
     def get_stripe_plan_id(cpu, ram, ssd, version, app='dcl', hdd=None):
         """
-        Returns the stripe plan id string of the form
+        Returns the Stripe plan id string of the form
         `dcl-v1-cpu-2-ram-5gb-ssd-10gb` based on the input parameters
 
         :param cpu: The number of cores
@@ -260,3 +260,14 @@ class StripeUtils(object):
                                                                  version=version,
                                                                  plan=dcl_plan_string)
         return stripe_plan_id_string
+
+    @staticmethod
+    def get_stripe_plan_name(cpu, memory, disk_size):
+        """
+        Returns the Stripe plan name
+        :return:
+        """
+        return "{cpu} Cores, {memory} GB RAM, {disk_size} GB SSD".format(
+                    cpu=cpu,
+                    memory=memory,
+                    disk_size=disk_size)

--- a/utils/stripe_utils.py
+++ b/utils/stripe_utils.py
@@ -256,9 +256,10 @@ class StripeUtils(object):
         if hdd is not None:
             dcl_plan_string = '{dcl_plan_string}-hdd-{hdd}gb'.format(
                 dcl_plan_string=dcl_plan_string, hdd=hdd)
-        stripe_plan_id_string = '{app}-v{version}-{plan}'.format(app=app,
-                                                                 version=version,
-                                                                 plan=dcl_plan_string)
+        stripe_plan_id_string = '{app}-v{version}-{plan}'.format(
+            app=app,
+            version=version,
+            plan=dcl_plan_string)
         return stripe_plan_id_string
 
     @staticmethod
@@ -268,6 +269,6 @@ class StripeUtils(object):
         :return:
         """
         return "{cpu} Cores, {memory} GB RAM, {disk_size} GB SSD".format(
-                    cpu=cpu,
-                    memory=memory,
-                    disk_size=disk_size)
+            cpu=cpu,
+            memory=memory,
+            disk_size=disk_size)


### PR DESCRIPTION
This PR proposes to refactor computation of VM price to `utils.hosting_utils.get_vm_price`. Also, getting of stripe plan name is refactored to `utils.stripe_utils.get_stripe_plan_name`.

I refactored price computation in two places:
1. datacenterlight/views.py
2. hosting/views.py