### PR TITLE
Enable logging custom modules

### DIFF
--- a/dynamicweb/settings/base.py
+++ b/dynamicweb/settings/base.py
@@ -586,20 +586,10 @@ if ENABLE_LOGGING:
     if MODULES_TO_LOG is None:
         # set MODULES_TO_LOG to django, if it is not set
         MODULES_TO_LOG = 'django'
-    if ',' in MODULES_TO_LOG:
-        modules_to_log_list = MODULES_TO_LOG.split(',')
-        for custom_module in modules_to_log_list:
-            logger_item = {
-                custom_module: {
-                    'handlers': ['custom_file'],
-                    'level': LOG_LEVEL,
-                    'propagate': True
-                }
-            }
-            loggers_dict.update(logger_item)
-    else:
+    modules_to_log_list = MODULES_TO_LOG.split(',')
+    for custom_module in modules_to_log_list:
         logger_item = {
-            MODULES_TO_LOG: {
+            custom_module: {
                 'handlers': ['custom_file'],
                 'level': LOG_LEVEL,
                 'propagate': True

--- a/dynamicweb/settings/base.py
+++ b/dynamicweb/settings/base.py
@@ -573,31 +573,19 @@ if DCL_ERROR_EMAILS_TO is not None:
 if 'info@ungleich.ch' not in DCL_ERROR_EMAILS_TO_LIST:
     DCL_ERROR_EMAILS_TO_LIST.append('info@ungleich.ch')
 
-ENABLE_DEBUG_LOGGING = bool_env('ENABLE_DEBUG_LOGGING')
-
-loggers_dict = {
-            'django': {
-                'handlers': ['file'],
-                'level': 'DEBUG',
-                'propagate': True,
-            },
-        }
-handlers_dict = {
-            'file': {
-                'level': 'DEBUG',
-                'class': 'logging.FileHandler',
-                'filename': "{PROJECT_DIR}/django-debug.log".format(
-                    PROJECT_DIR=PROJECT_DIR),
-            },
-}
-
+ENABLE_LOGGING = bool_env('ENABLE_LOGGING')
 MODULES_TO_LOG = env('MODULES_TO_LOG')
 LOG_LEVEL = env('LOG_LEVEL')
 
 if LOG_LEVEL is None:
     LOG_LEVEL = 'DEBUG'
 
-if MODULES_TO_LOG:
+if ENABLE_LOGGING:
+    loggers_dict = {}
+    handlers_dict = {}
+    if MODULES_TO_LOG is None:
+        # set MODULES_TO_LOG to django, if it is not set
+        MODULES_TO_LOG = 'django'
     if ',' in MODULES_TO_LOG:
         modules_to_log_list = MODULES_TO_LOG.split(',')
         for custom_module in modules_to_log_list:
@@ -624,15 +612,13 @@ if MODULES_TO_LOG:
             'level': LOG_LEVEL,
             'class': 'logging.FileHandler',
             'filename':
-                "{PROJECT_DIR}/custom_{LEVEL}.log".format(
+                "{PROJECT_DIR}/{LEVEL}.log".format(
                     LEVEL=LOG_LEVEL.lower(),
                     PROJECT_DIR=PROJECT_DIR
                 )
         }
     }
     handlers_dict.update(custom_handler_item)
-
-if ENABLE_DEBUG_LOGGING:
     LOGGING = {
         'version': 1,
         'disable_existing_loggers': False,

--- a/dynamicweb/settings/base.py
+++ b/dynamicweb/settings/base.py
@@ -586,16 +586,16 @@ handlers_dict = {
             'file': {
                 'level': 'DEBUG',
                 'class': 'logging.FileHandler',
-                'filename': "{PROJECT_DIR}/debug.log".format(
+                'filename': "{PROJECT_DIR}/django-debug.log".format(
                     PROJECT_DIR=PROJECT_DIR),
             },
 }
 
 MODULES_TO_LOG = env('MODULES_TO_LOG')
-MODULES_TO_LOG_LEVEL = env('MODULES_TO_LOG_LEVEL')
+LOG_LEVEL = env('LOG_LEVEL')
 
-if MODULES_TO_LOG_LEVEL is None:
-    MODULES_TO_LOG_LEVEL = 'DEBUG'
+if LOG_LEVEL is None:
+    LOG_LEVEL = 'DEBUG'
 
 if MODULES_TO_LOG:
     if ',' in MODULES_TO_LOG:
@@ -604,7 +604,7 @@ if MODULES_TO_LOG:
             logger_item = {
                 custom_module: {
                     'handlers': ['custom_file'],
-                    'level': MODULES_TO_LOG_LEVEL,
+                    'level': LOG_LEVEL,
                     'propagate': True
                 }
             }
@@ -613,7 +613,7 @@ if MODULES_TO_LOG:
         logger_item = {
             MODULES_TO_LOG: {
                 'handlers': ['custom_file'],
-                'level': MODULES_TO_LOG_LEVEL,
+                'level': LOG_LEVEL,
                 'propagate': True
             }
         }
@@ -621,11 +621,11 @@ if MODULES_TO_LOG:
 
     custom_handler_item = {
         'custom_file': {
-            'level': MODULES_TO_LOG_LEVEL,
+            'level': LOG_LEVEL,
             'class': 'logging.FileHandler',
             'filename':
                 "{PROJECT_DIR}/custom_{LEVEL}.log".format(
-                    LEVEL=MODULES_TO_LOG_LEVEL.lower(),
+                    LEVEL=LOG_LEVEL.lower(),
                     PROJECT_DIR=PROJECT_DIR
                 )
         }

--- a/opennebula_api/models.py
+++ b/opennebula_api/models.py
@@ -301,12 +301,14 @@ class OpenNebulaManager():
                    </CONTEXT>
                 </TEMPLATE>
                 """
-        vm_id = self.client.call(oca.VmTemplate.METHODS['instantiate'],
-                                 template.id,
-                                 '',
-                                 True,
-                                 vm_specs,
-                                 False)
+        try:
+            vm_id = self.client.call(
+                oca.VmTemplate.METHODS['instantiate'], template.id, '', True,
+                vm_specs, False
+            )
+        except OpenNebulaException as err:
+            logger.error("OpenNebulaException: {0}".format(err))
+            return None
 
         self.oneadmin_client.call(
             oca.VirtualMachine.METHODS['action'],


### PR DESCRIPTION
I found it rather difficult to debug a particular module in the source code. Everytime I wanted to do a debug, I had to change base.py (loggers and handlers), which is not so elegant.

In this PR, I propose to introduce three variables that can allow us to debug different modules without much of a hassle.

```
# If set to True, saves the logs from the supplied modules to files
ENABLE_LOGGING=True

# A comma separated string containing all modules to be logged. 
# This param is optional. If not set, it defaults to 'django'
MODULES_TO_LOG='django,hosting,opennebula_api'

# Supported values: DEBUG, INFO, WARNING, ERROR, CRITICAL. 
# See https://docs.djangoproject.com/en/1.11/topics/logging/#loggers
# This param is optional. It defaults to 'DEBUG'
LOG_LEVEL='DEBUG'
```
As you might have guessed, a server restart is necessary.