### PR TITLE
Task/3911/integrate resend activation link

### DIFF
--- a/datacenterlight/templates/datacenterlight/landing_payment.html
+++ b/datacenterlight/templates/datacenterlight/landing_payment.html
@@ -39,7 +39,7 @@
                         <p>
                             {% trans "Don't have an account yet?" %}<br>
                             {% trans "You can sign up by filling in the information below." %}<br>
-                            <a href="{% url 'hosting:reset_password' %}">{% trans "Forgot password?" %}</a>
+                            <a href="{% url 'hosting:reset_password' %}">{% trans "Forgot password?" %}</a> or <a href="{% url 'hosting:resend_activation_link' %}">{% trans "Resend activation link" %}?</a>
                         </p>
                     {% endif %}
                 </div>

--- a/datacenterlight/templates/datacenterlight/landing_payment.html
+++ b/datacenterlight/templates/datacenterlight/landing_payment.html
@@ -39,7 +39,7 @@
                         <p>
                             {% trans "Don't have an account yet?" %}<br>
                             {% trans "You can sign up by filling in the information below." %}<br>
-                            <a href="{% url 'hosting:reset_password' %}" _target="blank">{% trans "Forgot password?" %}</a> or <a href="{% url 'hosting:resend_activation_link' %}" _target="blank">{% trans "Resend activation link" %}?</a>
+                            <a href="{% url 'hosting:reset_password' %}" target="_blank">{% trans "Forgot password?" %}</a> or <a href="{% url 'hosting:resend_activation_link' %}" target="_blank">{% trans "Resend activation link" %}?</a>
                         </p>
                     {% endif %}
                 </div>

--- a/datacenterlight/templates/datacenterlight/landing_payment.html
+++ b/datacenterlight/templates/datacenterlight/landing_payment.html
@@ -39,7 +39,7 @@
                         <p>
                             {% trans "Don't have an account yet?" %}<br>
                             {% trans "You can sign up by filling in the information below." %}<br>
-                            <a href="{% url 'hosting:reset_password' %}">{% trans "Forgot password?" %}</a> or <a href="{% url 'hosting:resend_activation_link' %}">{% trans "Resend activation link" %}?</a>
+                            <a href="{% url 'hosting:reset_password' %}" _target="blank">{% trans "Forgot password?" %}</a> or <a href="{% url 'hosting:resend_activation_link' %}" _target="blank">{% trans "Resend activation link" %}?</a>
                         </p>
                     {% endif %}
                 </div>


### PR DESCRIPTION
This PR proposes two minor changes.
1. Add "resend activation link" to landing payment page
2. Use target = _blank for the links, so that they open corresponding pages in a new window