### PR TITLE
Update psycopg2 from 2.6.1 to 2.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ lxml==3.6.0
 model-mommy==1.2.6
 phonenumbers==7.4.0
 phonenumberslite==7.4.0
-psycopg2==2.6.1
+psycopg2==2.7.1
 pycryptodome==3.4
 pylibmc==1.5.1
 python-dateutil==2.5.3


### PR DESCRIPTION
psycopg2-2.6.1 was throwing this error while running automated tests:
```
     Error: could not determine PostgreSQL version from '10.1'
```
To test, whether our site functions properly after this. All the automated tests passed, so I expect the change to have no impact.