### PR TITLE
bugfix/4067 ungleich landing navbar fix

### DIFF
--- a/ungleich_page/static/ungleich_page/js/ungleich.js
+++ b/ungleich_page/static/ungleich_page/js/ungleich.js
@@ -15,3 +15,30 @@ function toggleImage(e) {
 	$this.fadeIn(300);
     });
 };
+
+/*!
+ * Start Bootstrap - Agnecy Bootstrap Theme (http://startbootstrap.com)
+ * Code licensed under the Apache License v2.0.
+ * For details, see http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+// jQuery for page scrolling feature - requires jQuery Easing plugin
+$(function() {
+    $('a.page-scroll').bind('click', function(event) {
+        var $anchor = $(this);
+        $('html, body').stop().animate({
+            scrollTop: $($anchor.attr('href')).offset().top
+        }, 1500, 'easeInOutExpo');
+        event.preventDefault();
+    });
+});
+
+// Highlight the top nav as scrolling occurs
+$('body').scrollspy({
+    target: '.navbar-fixed-top'
+})
+
+// Closes the Responsive Menu on Menu Item Click
+$('.navbar-collapse ul li a').click(function() {
+    $('.navbar-toggle:visible').click();
+});


### PR DESCRIPTION
Fixed in this PR:
- On mobile, the navbar closes on clicking any menu item.
- Easy scrolling enabled.
- Menu item highlight on select.