### PR TITLE
task/4166/dcl fix scroll

### DIFF
--- a/datacenterlight/static/datacenterlight/js/main.js
+++ b/datacenterlight/static/datacenterlight/js/main.js
@@ -107,7 +107,7 @@
             $('.navbar-collapse').addClass('collapsing');
             if ($(href).length) {
                 $('html, body').animate({
-                    scrollTop: $(href).offset().top
+                    scrollTop: $(href).offset().top - 50
                 }, 1000);
             }
         });

--- a/ungleich_page/static/ungleich_page/css/glasfaser.css
+++ b/ungleich_page/static/ungleich_page/css/glasfaser.css
@@ -12,7 +12,7 @@
 .navbar-default .navbar-nav>li>a {
     text-transform: uppercase;
     font-weight: 400;
-    letter-spacing: 1px;
+    letter-spacing: 0.5px;
     color: #777;
 }
 .navbar-transparent .navbar-nav>li>a {


### PR DESCRIPTION
Reduces the number of pixels the screen is scrolled on click to leave space for the navbar at top and keep the section heading in view.