### PR TITLE
Remove datacentelright_content placeholder conf

### DIFF
--- a/datacenterlight/templates/datacenterlight/cms/base.html
+++ b/datacenterlight/templates/datacenterlight/cms/base.html
@@ -57,7 +57,7 @@
         </div>
     {% endplaceholder %}
 
-    {% placeholder 'datacenterlight_content' %}
+    {% placeholder 'Datacenterlight Content' %}
 
     {% placeholder 'datacenterlight_footer'%}
 

--- a/dynamicweb/settings/base.py
+++ b/dynamicweb/settings/base.py
@@ -352,18 +352,6 @@ CMS_PLACEHOLDER_CONF = {
             },
         ]
     },
-    'datacenterlight_content': {
-        'name': _('Datacenterlight Content'),
-        'default_plugins': [
-            {
-                'plugin_type': 'DCLCalculatorPlugin',
-                'values': {
-                    'heading': 'Heading',
-                    'content': 'Text'
-                },
-            },
-        ]
-    },
 }
 
 CMS_PERMISSION = True


### PR DESCRIPTION
The placeholder conf seems to force the calculator form to appear in an empty page even if we have removed the corresponding DCLCalculator plugin. This seems more like a CMS bug to me. So, temporarily removing the placeholder conf code, which seems to work.