### PR TITLE
redirect old dcl landing to cms dcl landing

### DIFF
--- a/datacenterlight/urls.py
+++ b/datacenterlight/urls.py
@@ -1,13 +1,15 @@
 from django.conf.urls import url
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, RedirectView
 
 from .views import (
     IndexView, PaymentOrderView, OrderConfirmationView,
     WhyDataCenterLightView, ContactUsView
 )
 
+
 urlpatterns = [
-    url(r'^$', IndexView.as_view(), name='index'),
+    url(r'^$', RedirectView.as_view(url='/cms/datacenterlight/'),
+        name='index'),
     url(r'^t/$', IndexView.as_view(), name='index_t'),
     url(r'^g/$', IndexView.as_view(), name='index_g'),
     url(r'^f/$', IndexView.as_view(), name='index_f'),


### PR DESCRIPTION
redirect from `https://datacenterlight.ch/en-us/datacenterlight/` to `https://datacenterlight.ch/en-us/datacenterlight/`