### PR TITLE
Bug/5308/Correct IPv6 VM name

### DIFF
--- a/opennebula_api/serializers.py
+++ b/opennebula_api/serializers.py
@@ -162,7 +162,10 @@ class VirtualMachineSerializer(serializers.Serializer):
             return '-'
 
     def get_name(self, obj):
-        return obj.name.lstrip('public-')
+        if obj.name.startswith('public-'):
+            return obj.name.lstrip('public-')
+        else:
+            return obj.name
 
 
 class VMTemplateSerializer(serializers.Serializer):


### PR DESCRIPTION
Leave 'ipv6only' as a part of the VM name if it starts with it